### PR TITLE
Opacity and Bump Textures

### DIFF
--- a/api/MPbrtContainer.m
+++ b/api/MPbrtContainer.m
@@ -77,11 +77,14 @@ classdef MPbrtContainer < MPbrtNode
             % find the first occurence of the node, if any
             
             % no trick, just compare against each nested object
-            nNested = numel(self.nested);
-            isGivenNode = false(1, nNested);
-            for nn = 1:nNested
-                isGivenNode(nn) = node == self.nested{nn};
-            end
+            % nNested = numel(self.nested);
+            % isGivenNode = false(1, nNested);
+            % for nn = 1:nNested
+            %    isGivenNode(nn) = node == self.nested{nn};
+            % end
+            
+            % Faster version
+            isGivenNode = node == self.nested;
         end
         
         function index = prepend(self, node)

--- a/import/mexximp/mPbrtImportMexximpMaterial.m
+++ b/import/mexximp/mPbrtImportMexximpMaterial.m
@@ -68,6 +68,7 @@ bumpTexture = queryProperties(properties,'textureSemantic','height','data','');
 
 %% Build the pbrt material.
 switch opacity
+    % If opaque use an uber material
     case 1
         pbrtMaterial = MPbrtElement.makeNamedMaterial(pbrtName, materialDefault.type);
         pbrtMaterial.parameters = materialDefault.parameters;
@@ -81,7 +82,7 @@ switch opacity
             end
         end
         
-        if ~isempty(materialSpecularParameter) && ~isempty(pbrtMaterial.getParameter(materialSpecularParameter))
+        if ~isempty(materialSpecularParameter) && ~isempty(pbrtMaterial.getParameter(materialSpecularParameter))paque 
             if ~isempty(specularTexture) && ischar(specularTexture)
                 [pbrtTextures{end+1}, textureName] = makeImageMap(specularTexture);
                 pbrtMaterial.setParameter(materialDiffuseParameter, 'texture', textureName);
@@ -90,12 +91,13 @@ switch opacity
             end
         end
         
+        % If not create a translucent material
     otherwise
         pbrtMaterial = MPbrtElement.makeNamedMaterial(pbrtName, 'translucent');
         % pbrtMaterial.setParameter('Kt','rgb', [opacity, opacity, opacity]);
         
         %pbrtMaterial.setParameter('index','float',indexOfRefraction);
-        pbrtMaterial.setParameter('reflect','rgb',[1 1 1]);
+        pbrtMaterial.setParameter('reflect','rgb',[opacity, opacity, opacity]);
         pbrtMaterial.setParameter('roughness','float',1);
         pbrtMaterial.setParameter('transmit','rgb',1-[opacity, opacity, opacity]);
         pbrtMaterial.setParameter('Kd','rgb',diffuseRgb(1:3));

--- a/import/mexximp/mPbrtImportMexximpMaterial.m
+++ b/import/mexximp/mPbrtImportMexximpMaterial.m
@@ -38,34 +38,49 @@ parser = inputParser();
 parser.KeepUnmatched = true;
 parser.addRequired('scene', @isstruct);
 parser.addRequired('material', @isstruct);
-parser.addParameter('materialDefault', MPbrtElement.makeNamedMaterial('', 'uber'), @isobject);
-parser.addParameter('materialDiffuseParameter', 'Kd', @ischar);
-parser.addParameter('materialSpecularParameter', 'Kr', @ischar);
-parser.addParameter('materialGlossyParameter', 'Ks', @ischar);
-parser.addParameter('materialIorParameter', 'index', @ischar);
-parser.addParameter('materialRoughnessParameter', 'roughness', @ischar);
-parser.addParameter('materialOpacityParameter', 'opacity', @ischar);
+% parser.addParameter('materialDefault', MPbrtElement.makeNamedMaterial('', 'uber'), @isobject);
+% parser.addParameter('materialDiffuseParameter', 'Kd', @ischar);
+% parser.addParameter('materialSpecularParameter', 'Kr', @ischar);
+% parser.addParameter('materialGlossyParameter', 'Ks', @ischar);
+% parser.addParameter('materialIorParameter', 'index', @ischar);
+% parser.addParameter('materialRoughnessParameter', 'roughness', @ischar);
+% parser.addParameter('materialOpacityParameter', 'opacity', @ischar);
 parser.parse(scene, material, varargin{:});
-scene = parser.Results.scene;
-material = parser.Results.material;
-materialDefault = parser.Results.materialDefault;
-materialDiffuseParameter = parser.Results.materialDiffuseParameter;
-materialSpecularParameter = parser.Results.materialSpecularParameter;
-materialGlossyParameter = parser.Results.materialGlossyParameter;
-materialIorParameter = parser.Results.materialIorParameter;
-materialRoughnessParameter = parser.Results.materialRoughnessParameter;
-materialOpacityParameter = parser.Results.materialOpacityParameter;
+% scene = parser.Results.scene;
+% material = parser.Results.material;
+% materialDefault = parser.Results.materialDefault;
+% materialDiffuseParameter = parser.Results.materialDiffuseParameter;
+% materialSpecularParameter = parser.Results.materialSpecularParameter;
+% materialGlossyParameter = parser.Results.materialGlossyParameter;
+% materialIorParameter = parser.Results.materialIorParameter;
+% materialRoughnessParameter = parser.Results.materialRoughnessParameter;
+% materialOpacityParameter = parser.Results.materialOpacityParameter;
+
+
+
+materialDefault = MPbrtElement.makeNamedMaterial('','uber');
+materialDefault.setParameter('Kd', 'spectrum', '300:1 800:1');
+materialDefault.setParameter('Ks', 'spectrum', '300:0 800:0');
+materialDefault.setParameter('Kr', 'spectrum', '300:0 800:0');
+materialDefault.setParameter('roughness','float',0.1);
+materialDefault.setParameter('index','float',1.5);
+materialDefault.setParameter('opacity', 'spectrum', '300:1 800:1');
+materialDiffuseParameter = 'Kd';
+materialSpecularParameter = 'Kr';
+materialGlossyParameter = 'Ks';
+materialIorParameter = 'index';
+materialOpacityParameter = 'opacity';
 
 pbrtTextures = {};
 
 %% Dig out the material name.
-materialName = material.name;
+materialName = parser.Results.material.name;
 
-materialIndex = material.path{end};
+materialIndex = parser.Results.material.path{end};
 pbrtName = mexximpCleanName(materialName, materialIndex);
 
 %% Dig out diffuse and specular rgb and texture values.
-properties = mPathGet(scene, cat(2, material.path, {'properties'}));
+properties = mPathGet(parser.Results.scene, cat(2, parser.Results.material.path, {'properties'}));
 diffuseRgb = mPbrtQueryProperties(properties, 'key', 'diffuse', 'data', []);
 specularRgb = mPbrtQueryProperties(properties, 'key', 'specular', 'data', []);
 glossyRgb = mPbrtQueryProperties(properties, 'key', 'glossy', 'data', []);
@@ -75,6 +90,8 @@ indexOfRefraction = mPbrtQueryProperties(properties, 'key', 'refract_i', 'data',
 
 transparency = mPbrtQueryProperties(properties, 'key', 'transparent', 'data', []);
 transparency = 1-transparency;
+
+shininess = mPbrtQueryProperties(properties, 'key', 'shininess', 'data', []);
 
 % emissiveRgb = queryProperties(properties, 'key', 'emissive', 'data', []);
 % shadingModel = queryProperties(properties, 'key', 'shading_model','data',0);
@@ -88,75 +105,81 @@ bumpTexture = mPbrtQueryProperties(properties, 'textureSemantic','height','data'
 
 %% Build the pbrt material.
 
-if max(transparency(:)) == 0
-    % Opaque material
-    
-    pbrtMaterial = MPbrtElement.makeNamedMaterial(pbrtName, materialDefault.type);
-    pbrtMaterial.parameters = materialDefault.parameters;
-    
-    if ~isempty(materialDiffuseParameter) && ~isempty(pbrtMaterial.getParameter(materialDiffuseParameter))
-        if ~isempty(diffuseTexture) && ischar(diffuseTexture)
-            [pbrtTextures{end+1}, textureName] = mPbrtMakeImageMap(diffuseTexture,'spectrum');
-            pbrtMaterial.setParameter(materialDiffuseParameter, 'texture', textureName);
-        elseif ~isempty(diffuseRgb)
-            pbrtMaterial.setParameter(materialDiffuseParameter, 'rgb', diffuseRgb(1:3));
-        end
+%if max(transparency(:)) == 0
+% Opaque material
+
+pbrtMaterial = MPbrtElement.makeNamedMaterial(pbrtName, materialDefault.type);
+pbrtMaterial.parameters = materialDefault.parameters;
+
+if ~isempty(materialDiffuseParameter) && ~isempty(pbrtMaterial.getParameter(materialDiffuseParameter))
+    if ~isempty(diffuseTexture) && ischar(diffuseTexture)
+        [pbrtTextures{end+1}, textureName] = mPbrtMakeImageMap(diffuseTexture,'spectrum');
+        pbrtMaterial.setParameter(materialDiffuseParameter, 'texture', textureName);
+    elseif ~isempty(diffuseRgb)
+        pbrtMaterial.setParameter(materialDiffuseParameter, 'rgb', diffuseRgb(1:3));
     end
-    
-    
-    if ~isempty(materialSpecularParameter) && ~isempty(pbrtMaterial.getParameter(materialSpecularParameter))
-        if ~isempty(specularTexture) && ischar(specularTexture)
-            [pbrtTextures{end+1}, textureName] = mPbrtMakeImageMap(specularTexture,'spectrum');
-            pbrtMaterial.setParameter(materialDiffuseParameter, 'texture', textureName);
-        elseif ~isempty(specularRgb)
-            pbrtMaterial.setParameter(materialSpecularParameter, 'rgb', specularRgb(1:3));
-        end
+end
+
+%{
+if ~isempty(materialSpecularParameter) && ~isempty(pbrtMaterial.getParameter(materialSpecularParameter))
+    if ~isempty(specularTexture) && ischar(specularTexture)
+        [pbrtTextures{end+1}, textureName] = mPbrtMakeImageMap(specularTexture,'spectrum');
+        pbrtMaterial.setParameter(materialDiffuseParameter, 'texture', textureName);
+    elseif ~isempty(specularRgb)
+        pbrtMaterial.setParameter(materialSpecularParameter, 'rgb', specularRgb(1:3));
     end
-    
-    if ~isempty(materialGlossyParameter) && ~isempty(pbrtMaterial.getParameter(materialGlossyParameter))
-        if ~isempty(glossyTexture) && ischar(glossyTexture)
-            [pbrtTextures{end+1}, textureName] = mPbrtMakeImageMap(glossyTexture,'spectrum');
-            pbrtMaterial.setParameter(materialGlossyParameter, 'texture', textureName);
-        elseif ~isempty(glossyRgb)
-            pbrtMaterial.setParameter(materialGlossyParameter, 'rgb', glossyRgb(1:3));
-        end
+end
+%}
+
+% The glossy parameter from PBRT is equivalent to Specular parameter from
+% OBJ/MTL
+if ~isempty(materialGlossyParameter) && ~isempty(pbrtMaterial.getParameter(materialGlossyParameter))
+    if ~isempty(specularTexture) && ischar(specularTexture) %isempty(glossyTexture) && ischar(glossyTexture)
+        [pbrtTextures{end+1}, textureName] = mPbrtMakeImageMap(specularTexture,'spectrum');
+        pbrtMaterial.setParameter(materialGlossyParameter, 'texture', textureName);
+    elseif ~isempty(specularRgb) %isempty(glossyRgb)
+        pbrtMaterial.setParameter(materialGlossyParameter, 'rgb', specularRgb(1:3));
     end
-    
-    if ~isempty(materialIorParameter) && ~isempty(pbrtMaterial.getParameter(materialIorParameter))
-        if ~isempty(iorTexture) && ischar(iorTexture)
-            [pbrtTextures{end+1}, textureName] = mPbrtImageImageMap(iorTexture,'float');
-            pbrtMaterial.setParameter(materialIorParameter, 'texture', textureName);
-        elseif ~isempty(indexOfRefraction)
-            pbrtMaterial.setParameter(materialIorParameter, 'float', indexOfRefraction);
-        end
+end
+
+if ~isempty(materialIorParameter) && ~isempty(pbrtMaterial.getParameter(materialIorParameter))
+    if ~isempty(iorTexture) && ischar(iorTexture)
+        [pbrtTextures{end+1}, textureName] = mPbrtImageImageMap(iorTexture,'float');
+        pbrtMaterial.setParameter(materialIorParameter, 'texture', textureName);
+    elseif ~isempty(indexOfRefraction)
+        pbrtMaterial.setParameter(materialIorParameter, 'float', indexOfRefraction);
     end
-    
-    if ~isempty(materialOpacityParameter) && ~isempty(pbrtMaterial.getParameter(materialOpacityParameter))
-        if ~isempty(opacityTexture) && ischar(opacityTexture)
-            [pbrtTextures{end+1}, textureName] = mPbrtMakeImageMap(opacityTexture,'spectrum');
-            pbrtMaterial.setParameter(materialOpacityParameter, 'texture', textureName);
-        elseif ~isempty(opacity)
-            pbrtMaterial.setParameter(materialOpacityParameter, 'rgb', [opacity, opacity, opacity]);
-        end
-    end
-    
-    
-    
-    
-    
-    % Add bump map if present
-    if ~isempty(bumpTexture)&& ischar(bumpTexture)
-        [pbrtTextures{end+1}, textureName] = mPbrtMakeImageMap(bumpTexture,'float');
-        materialBumpParameter = 'bumpmap';
-        pbrtMaterial.setParameter(materialBumpParameter, 'texture', textureName);
-    end
-    
-    % Create an opacity (i.e. mask) texture if present. This texture is later linked in
-    % mPbrtImportMexximpMesh.
+end
+
+if ~isempty(materialOpacityParameter) && ~isempty(pbrtMaterial.getParameter(materialOpacityParameter))
     if ~isempty(opacityTexture) && ischar(opacityTexture)
-        [pbrtTextures{end+1}, ~] = mPbrtMakeImageMap(opacityTexture,'float');
+        [pbrtTextures{end+1}, textureName] = mPbrtMakeImageMap(opacityTexture,'float');
+        pbrtMaterial.setParameter(materialOpacityParameter, 'texture', textureName);
+    elseif ~isempty(opacity)
+        pbrtMaterial.setParameter(materialOpacityParameter, 'rgb', [opacity, opacity, opacity]);
     end
-    
+end
+
+% Roughness in PBRT is 1/shininess from OBJ/MTL file
+if ~isempty(shininess)
+    pbrtMaterial.setParameter('roughness', 'float', 1/shininess);
+end
+
+
+
+% Add bump map if present
+if ~isempty(bumpTexture)&& ischar(bumpTexture)
+    [pbrtTextures{end+1}, textureName] = mPbrtMakeImageMap(bumpTexture,'float');
+    materialBumpParameter = 'bumpmap';
+    pbrtMaterial.setParameter(materialBumpParameter, 'texture', textureName);
+end
+
+% Create an opacity (i.e. mask) texture if present. This texture is later linked in
+% mPbrtImportMexximpMesh.
+if ~isempty(opacityTexture) && ischar(opacityTexture)
+    [pbrtTextures{end+1}, ~] = mPbrtMakeImageMap(opacityTexture,'float');
+end
+%{
 else
     % glass material
     pbrtMaterial = MPbrtElement.makeNamedMaterial(pbrtName, 'glass');
@@ -175,5 +198,5 @@ else
     
     
 end
-
+%}
 

--- a/import/mexximp/mPbrtImportMexximpMaterial.m
+++ b/import/mexximp/mPbrtImportMexximpMaterial.m
@@ -61,9 +61,9 @@ specularRgb = mPbrtQueryProperties(properties, 'key', 'specular', 'data', []);
 diffuseTexture = mPbrtQueryProperties(properties, 'textureSemantic', 'diffuse', 'data', '');
 specularTexture = mPbrtQueryProperties(properties, 'textureSemantic', 'specular', 'data', '');
 
-emissiveRgb = queryProperties(properties, 'key', 'emissive', 'data', []);
-opacity = queryProperties(properties, 'key', 'opacity', 'data', []);
-indexOfRefraction = queryProperties(properties, 'key', 'refract_i', 'data', []);
+emissiveRgb = mPbrtQueryProperties(properties, 'key', 'emissive', 'data', []);
+opacity = mPbrtQueryProperties(properties, 'key', 'opacity', 'data', []);
+indexOfRefraction = mPbrtQueryProperties(properties, 'key', 'refract_i', 'data', []);
 
 bumpTexture = mPbrtQueryProperties(properties,'textureSemantic','height','data','');
 opacityTexture = mPbrtQueryProperties(properties,'textureSemantic','opacity','data',''); % mask texture
@@ -98,7 +98,7 @@ if ~isempty(materialSpecularParameter) && ~isempty(pbrtMaterial.getParameter(mat
             
             if ~isempty(materialDiffuseParameter) && ~isempty(pbrtMaterial.getParameter(materialDiffuseParameter))
                 if ~isempty(diffuseTexture) && ischar(diffuseTexture)
-                    [pbrtTextures{end+1}, textureName] = makeImageMap(diffuseTexture);
+                    [pbrtTextures{end+1}, textureName] = mPbrtMakeImageMap(diffuseTexture,'spectrum');
                     pbrtMaterial.setParameter(materialDiffuseParameter, 'texture', textureName);
                 elseif ~isempty(diffuseRgb)
                     pbrtMaterial.setParameter(materialDiffuseParameter, 'rgb', diffuseRgb(1:3));
@@ -107,7 +107,7 @@ if ~isempty(materialSpecularParameter) && ~isempty(pbrtMaterial.getParameter(mat
             
             if ~isempty(materialSpecularParameter) && ~isempty(pbrtMaterial.getParameter(materialSpecularParameter))paque
                 if ~isempty(specularTexture) && ischar(specularTexture)
-                    [pbrtTextures{end+1}, textureName] = makeImageMap(specularTexture);
+                    [pbrtTextures{end+1}, textureName] = mPbrtMakeImageMap(specularTexture,'spectrum');
                     pbrtMaterial.setParameter(materialDiffuseParameter, 'texture', textureName);
                 elseif ~isempty(specularRgb)
                     pbrtMaterial.setParameter(materialSpecularParameter, 'rgb', specularRgb(1:3));

--- a/import/mexximp/mPbrtImportMexximpMaterial.m
+++ b/import/mexximp/mPbrtImportMexximpMaterial.m
@@ -105,9 +105,6 @@ bumpTexture = mPbrtQueryProperties(properties, 'textureSemantic','height','data'
 
 %% Build the pbrt material.
 
-%if max(transparency(:)) == 0
-% Opaque material
-
 pbrtMaterial = MPbrtElement.makeNamedMaterial(pbrtName, materialDefault.type);
 pbrtMaterial.parameters = materialDefault.parameters;
 
@@ -153,7 +150,7 @@ end
 
 if ~isempty(materialOpacityParameter) && ~isempty(pbrtMaterial.getParameter(materialOpacityParameter))
     if ~isempty(opacityTexture) && ischar(opacityTexture)
-        [pbrtTextures{end+1}, textureName] = mPbrtMakeImageMap(opacityTexture,'float');
+        [pbrtTextures{end+1}, textureName] = mPbrtMakeImageMap(opacityTexture,'spectrum');
         pbrtMaterial.setParameter(materialOpacityParameter, 'texture', textureName);
     elseif ~isempty(opacity)
         pbrtMaterial.setParameter(materialOpacityParameter, 'rgb', [opacity, opacity, opacity]);
@@ -176,27 +173,11 @@ end
 
 % Create an opacity (i.e. mask) texture if present. This texture is later linked in
 % mPbrtImportMexximpMesh.
+% We export opacity maps both as floats and spectrum because the two representations are used
+% for textures (spectrum) and meshes (float).
 if ~isempty(opacityTexture) && ischar(opacityTexture)
+    [pbrtTextures{end+1}, ~] = mPbrtMakeImageMap(opacityTexture,'spectrum');
     [pbrtTextures{end+1}, ~] = mPbrtMakeImageMap(opacityTexture,'float');
 end
-%{
-else
-    % glass material
-    pbrtMaterial = MPbrtElement.makeNamedMaterial(pbrtName, 'glass');
-    pbrtMaterial.setParameter('Ks', 'rgb', [1 1 1]);
-    pbrtMaterial.setParameter('Kt', 'rgb', transparency);
-    pbrtMaterial.setParameter(materialIorParameter, 'float', indexOfRefraction);
-    
-    if ~isempty(materialSpecularParameter) && ~isempty(pbrtMaterial.getParameter(materialSpecularParameter))
-        if ~isempty(specularTexture) && ischar(specularTexture)
-            [pbrtTextures{end+1}, textureName] = mPbrtMakeImageMap(specularTexture,'spectrum');
-            pbrtMaterial.setParameter(materialDiffuseParameter, 'texture', textureName);
-        elseif ~isempty(specularRgb)
-            pbrtMaterial.setParameter(materialSpecularParameter, 'rgb', specularRgb(1:3));
-        end
-    end
-    
-    
-end
-%}
+
 

--- a/import/mexximp/mPbrtImportMexximpMesh.m
+++ b/import/mexximp/mPbrtImportMexximpMesh.m
@@ -117,6 +117,26 @@ pbrtNode.append(pbrtMaterial);
 pbrtInclude = MPbrtElement('Include', 'value', includeRelativePath);
 pbrtNode.append(pbrtInclude);
 
+% If the material has an opacity texture, we need to write it out here in
+% the mesh. Unfortunately, we don't seem to have access to the MPbrtElement
+% container that holds the material properties. As a hack, let's just check
+% the materialData for opacity textures, and "guess" the Texture name based
+% on how we named it in mPbrtImportMexximpMaterial.
+% This is not really elegant at all...but it works.
+opacityDataQuery = {'textureSemantic', mexximpStringMatcher('opacity')};
+opacityDataPath = {'properties', opacityDataQuery, 'data'};
+opacityData = mPathGet(materialData, opacityDataPath);
+% Sometimes the above lines pick up the "height" textureSemantic? Why? To
+% avoid this, we double check for the "opacity" textureSemantic in the if
+% statement below.
+opacityTextureSemanticPath = {'properties', opacityDataQuery, 'textureSemantic'}; 
+textureSemanticCheck = mPathGet(materialData, opacityTextureSemanticPath);
+if(strcmp(textureSemanticCheck,'opacity') && ~isempty(opacityData))
+   [~, textureName] = fileparts(opacityData);
+   pbrtOpacity = MPbrtElement('"texture alpha"','value',textureName);
+   pbrtNode.append(pbrtOpacity);
+end
+
 %% If necessary, write the include file.
 if 2 == exist(includeFile, 'file') && ~rewriteMeshData
     % use an existing Include file

--- a/import/mexximp/mPbrtImportMexximpMesh.m
+++ b/import/mexximp/mPbrtImportMexximpMesh.m
@@ -117,22 +117,18 @@ pbrtNode.append(pbrtMaterial);
 pbrtInclude = MPbrtElement('Include', 'value', includeRelativePath);
 pbrtNode.append(pbrtInclude);
 
-% If the material has an opacity texture, we need to write it out here in
-% the mesh. Unfortunately, we don't seem to have access to the MPbrtElement
-% container that holds the material properties. As a hack, let's just check
-% the materialData for opacity textures, and "guess" the Texture name based
-% on how we named it in mPbrtImportMexximpMaterial.
-% This is not really elegant at all...but it works.
-opacityDataQuery = {'textureSemantic', mexximpStringMatcher('opacity')};
-opacityDataPath = {'properties', opacityDataQuery, 'data'};
-opacityData = mPathGet(materialData, opacityDataPath);
-% Sometimes the above lines pick up the "height" textureSemantic? Why? To
-% avoid this, we double check for the "opacity" textureSemantic in the if
-% statement below.
-opacityTextureSemanticPath = {'properties', opacityDataQuery, 'textureSemantic'}; 
-textureSemanticCheck = mPathGet(materialData, opacityTextureSemanticPath);
-if(strcmp(textureSemanticCheck,'opacity') && ~isempty(opacityData))
-   [~, textureName] = fileparts(opacityData);
+
+%% Check for opacity textures
+opacityTexture = mPbrtQueryProperties(materialData.properties,'textureSemantic','opacity','data','');
+if(~isempty(opacityTexture)) 
+    
+    % Hack to get texture name. We use mPbrtMakeImageMap in
+    % mPbrtimportMexximpMaterial in order to create the named texture.
+    % We cannot create the texture here, since it cannot within the Object
+    % instance (pbrtNode container).
+   [~, textureName] = mPbrtMakeImageMap(opacityTexture,'float');
+   
+   % Attach to mesh
    pbrtOpacity = MPbrtElement('"texture alpha"','value',textureName);
    pbrtNode.append(pbrtOpacity);
 end

--- a/import/mexximp/mPbrtMakeImageMap.m
+++ b/import/mexximp/mPbrtMakeImageMap.m
@@ -1,0 +1,12 @@
+%% Make an imagemap texture with a name like its image file.
+% This function was originally elevated from mPbrtImportMexximpMaterial.
+
+% Example: [pbrtTextures{end+1}, textureName] =
+% makeImageMap(diffuseTexture,'spectrum');
+
+% Trisha Lian
+
+function [texture, textureName] = mPbrtMakeImageMap(imageFile,textureType)
+[~, textureName] = fileparts(imageFile);
+texture = MPbrtElement.texture(textureName, textureType, 'imagemap');
+texture.setParameter('filename', 'string', imageFile);

--- a/import/mexximp/mPbrtMakeImageMap.m
+++ b/import/mexximp/mPbrtMakeImageMap.m
@@ -1,5 +1,7 @@
 %% Make an imagemap texture with a name like its image file.
 % This function was originally elevated from mPbrtImportMexximpMaterial.
+% We append the texture type to texture name because the same texture can
+% be also used as a bumpmap, in which case its type is different.
 
 % Example: [pbrtTextures{end+1}, textureName] =
 % makeImageMap(diffuseTexture,'spectrum');
@@ -8,5 +10,6 @@
 
 function [texture, textureName] = mPbrtMakeImageMap(imageFile,textureType)
 [~, textureName] = fileparts(imageFile);
+textureName = sprintf('%s_%s',textureName,textureType);
 texture = MPbrtElement.texture(textureName, textureType, 'imagemap');
 texture.setParameter('filename', 'string', imageFile);

--- a/import/mexximp/mPbrtQueryProperties.m
+++ b/import/mexximp/mPbrtQueryProperties.m
@@ -1,0 +1,19 @@
+%% Query a material property, return default if no good match.
+% This function was originally elevated from mPbrtImportMexximpMaterial. It
+% is used to extract a specific value from the properties of a material
+% imported from assimp.
+
+% Example:
+% diffuseRgb = queryProperties(properties, 'key', 'diffuse', 'data', []);
+
+% Trisha Lian
+
+function result = mPbrtQueryProperties(properties, queryField, queryValue, resultField, defaultResult)
+query = {queryField, mexximpStringMatcher(queryValue)};
+[resultIndex, resultScore] = mPathQuery(properties, query);
+if 1 == resultScore
+    result = properties(resultIndex).(resultField);
+else
+    result = defaultResult;
+end
+


### PR DESCRIPTION
Hi @benjamin-heasly,

I made some additions to mPBRT to be able to recognize bump textures and opacity textures from the mexximp structure, and then to write them out appropriately in the PBRT file. The bump texture was straightforward...the opacity texture, not so much.

Judging from the example scenes on PBRT, the call to the opacity texture ("texture alpha xxxx") has to occur in the ObjectBegin/End of the mesh with the corresponding material. For example:

```
# 2_Material__57
ObjectBegin "2_Material__57"
  NamedMaterial "2_Material__57"   
  Include "scenes/PBRT/pbrt-geometry/2_Material__57.pbrt"   
  "texture alpha" "vase_plant_mask"   
ObjectEnd
```
If you place it in the MakeNamedMaterial section with all the other texture calls, it won't be applied. I suppose this makes sense, since the texture specifically affects the mesh.

To get around this, I create the Texture in the mPbrtImportMexximpMaterial.m, and then do a sort of hack where I just check if there is an opacity texture in the materials of mPbrtImportMexximpMesh.m and link it to the Texture with the same name. I don't think this is the best way to do things, but I'm not sure I can see another way. Maybe you have some ideas?

I have a simple example scene to test the bump and opacity textures, which I will shortly be putting up on a new branch of RTB4. 

Let me know if this makes any sense to you, or if you have some ideas. Thanks!

 